### PR TITLE
fix(build): legacy shims for Amplify

### DIFF
--- a/b2b-simple/_lib_legacy/ctAuth.js
+++ b/b2b-simple/_lib_legacy/ctAuth.js
@@ -1,0 +1,2 @@
+export { getCTToken } from "../src/lib/ctAuth";
+export default { getCTToken };

--- a/b2b-simple/lib/ctRest.js
+++ b/b2b-simple/lib/ctRest.js
@@ -1,2 +1,2 @@
-export * from './ct-rest.js';
-export { default } from './ct-rest.js';
+export * from "./ct-rest.js";
+export { default } from "./ct-rest.js";


### PR DESCRIPTION
Adds _lib_legacy/ctAuth.js and normalizes lib/ct-rest exports for legacy import surface.